### PR TITLE
[HardwareUtil] Failed to get Hardware UUID ' fix' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ When `JAVA_DEBUG=true`, the server starts with the following JVM argument:
 - **Suspend on Start**: To make the server wait for the debugger before starting, you can modify the entrypoint script or use `JAVA_JVM_ARGS` with `suspend=y`
 - **Remote Debugging**: If debugging from a different machine, ensure port `5005` is accessible and use the server's IP address instead of `localhost`
 - **Performance**: Debug mode may slightly impact server performance. Disable it in production environments
+- **Machine UUID**: When your docker-desktop / WSL installation does not have a machine-id yet. Run `uuidgen | sudo tee /etc/machine-id` in WSL  
 
 ## Notes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             - "5520:5520/udp"
         volumes:
             - ./hytale:/hytale
+            - /etc/machine-id:/etc/machine-id:ro
         env_file:
             - path: .env
               required: false


### PR DESCRIPTION
When using this image we ran into the issue ([HardwareUtil] Failed to get Hardware UUID) that it would not start because there was no machine-id (UUID) present. This PR should prevent the issue from happening again.